### PR TITLE
Отключение авто-эвака через время (запрос в войсе от Condor134)

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1526,7 +1526,7 @@ namespace Content.Shared.CCVar
         ///     Time in minutes after round start to auto-call the shuttle. Set to zero to disable.
         /// </summary>
         public static readonly CVarDef<int> EmergencyShuttleAutoCallTime =
-            CVarDef.Create("shuttle.auto_call_time", 90, CVar.SERVERONLY);
+            CVarDef.Create("shuttle.auto_call_time", 0, CVar.SERVERONLY);
 
         /// <summary>
         ///     Time in minutes after the round was extended (by recalling the shuttle) to call

--- a/Resources/Prototypes/Catalog/Jukebox/Standard.yml
+++ b/Resources/Prototypes/Catalog/Jukebox/Standard.yml
@@ -39,3 +39,63 @@
   name: PigeonBeans - Sunset
   path:
     path: /Audio/Jukebox/sunset.ogg
+
+- type: jukebox
+  id: SpaceAsshole
+  name: Chris Remo - Space Asshole
+  path:
+    path: /Audio/Lobby/space_asshole.ogg
+
+- type: jukebox
+  id: engineerz
+  name: David Bowie - Engineers
+  path:
+    path: /Audio/Lobby/Engineerz.ogg
+
+- type: jukebox
+  id: title2
+  name: Eric Shumaker - Title2
+  path:
+    path: /Audio/Lobby/title2.ogg
+
+- type: jukebox
+  id: andromeda
+  name: Radium - Andromeda
+  path:
+    path: /Audio/Radium/Lobby/Andromeda.ogg
+
+- type: jukebox
+  id: apex
+  name: Radium - Apex
+  path:
+    path: /Audio/Radium/Lobby/Apex.ogg
+
+- type: jukebox
+  id: quasar
+  name: Radium - Quasar
+  path:
+    path: /Audio/Radium/Lobby/Quasar.ogg
+
+- type: jukebox
+  id: maxwell
+  name: Maxwell
+  path:
+    path: /Audio/Radium/Maxwell/maxwell.ogg
+
+- type: jukebox
+  id: deadline
+  name: Bolgarich - Deadline
+  path:
+    path: /Audio/Expedition/deadline.ogg
+
+- type: jukebox
+  id: countdown
+  name: Qwertyquerty - Countdown
+  path:
+    path: /Audio/StationEvents/countdown.ogg
+
+- type: jukebox
+  id: runningout
+  name: Bolgarich - Running Out
+  path:
+    path: /Audio/StationEvents/running_out.ogg


### PR DESCRIPTION
## Описание PR

Убрал авто-вызов шаттла смены экипажа через определенное время по запросу condor134 (нет Issue, попросили в войсе)

Добавил немного треков в проигрыватель музыки

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [ ] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [ ] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**
:cl: Xo6a
- add: Новые треки в проигрывателе музыки! (Jukebox)
- remove: -
- tweak: Эвакуационный шаттл/процедура смены экипажа более не будут происходить на сервере. Теперь игроки сами должны будут вызывать эвак для окончания раунда!
- fix: -
