### PR TITLE
HealthScanner now shows hurt limbs!

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerBoundUserInterface.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerBoundUserInterface.cs
@@ -1,12 +1,17 @@
-﻿using Content.Shared.MedicalScanner;
+﻿using Content.Client.Radium.Medical.Surgery.UI.Widgets.Systems;
+using Content.Shared.MedicalScanner;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
+using Content.Shared.Radium.Medical.Surgery.Systems;
 
 namespace Content.Client.HealthAnalyzer.UI
 {
     [UsedImplicitly]
     public sealed class HealthAnalyzerBoundUserInterface : BoundUserInterface
     {
+        [Dependency] private readonly ClientDamagePartsSystem _damageParts = default!;
+        [Dependency] private readonly EntityManager _entityManager = default!;
+
         [ViewVariables]
         private HealthAnalyzerWindow? _window;
 
@@ -32,6 +37,13 @@ namespace Content.Client.HealthAnalyzer.UI
 
             if (message is not HealthAnalyzerScannedUserMessage cast)
                 return;
+
+            var targetEntity = _entityManager.GetEntity(cast.TargetEntity);
+
+            if (targetEntity != null){
+                var damagedParts = _damageParts.GetDamagedParts(targetEntity.Value);
+                cast.DamagedBodyParts = damagedParts;
+            }
 
             _window.Populate(cast);
         }

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -1,7 +1,9 @@
 ﻿<controls:FancyWindow
     xmlns="https://spacestation14.io"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ui="clr-namespace:Content.Client.ContextMenu.UI"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-    SetSize="650 530"
+    SetSize="650 570"
     Resizable="False">
     <ScrollContainer
         VerticalExpand="True">
@@ -50,7 +52,9 @@
                     Orientation="Vertical">
                 </BoxContainer>
                 <controls:HLine Color="#113E1B" SetHeight="5" Margin="-40 0 0 0" SetWidth="605"></controls:HLine>
-                <Label Name="SurgeryNameLabel" Margin="0 10 0 0" />
+                <Label Name="SurgeryNameLabel" HorizontalAlignment="Left" Margin="0 24 0 0"/>
+                        <!--<Label Name="BodyPartsDescription" Margin="0 10 0 0" HorizontalAlignment="Left"></Label> -->
+
                 <Label Name="SurgeryProcedureLabel" Margin="0 5 0 0" />
                 <BoxContainer Orientation="Horizontal" VerticalAlignment="Center">
                     <Label Name="SurgeryStepDesc" Margin="0 10 0 0"></Label>
@@ -58,6 +62,14 @@
                     <Label Name="SurgeryStep" Margin="0 10 0 0"></Label>
                 </BoxContainer>
             </BoxContainer>
+            <TextureRect Name="BaseDollTransparent" Stretch="Scale" SetSize="128 128" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0 0 12 24">
+                <TextureRect Name="BodyPartIconHead" VerticalAlignment="Center" Margin="48 0 48 24" HorizontalAlignment="Center" Stretch="Scale" SetSize="128 128"></TextureRect>
+                <TextureRect Name="BodyPartIconTorso" VerticalAlignment="Center" Margin="48 0 48 24" HorizontalAlignment="Center" Stretch="Scale" SetSize="128 128"></TextureRect>
+                <TextureRect Name="BodyPartIconLeftHand" VerticalAlignment="Center" Margin="48 0 48 24" HorizontalAlignment="Center" Stretch="Scale" SetSize="128 128"></TextureRect>
+                <TextureRect Name="BodyPartIconRightHand" VerticalAlignment="Center" Margin="48 0 48 24" HorizontalAlignment="Center" Stretch="Scale" SetSize="128 128"></TextureRect>
+                <TextureRect Name="BodyPartIconLeftLeg" VerticalAlignment="Center" Margin="48 0 48 24" HorizontalAlignment="Center" Stretch="Scale" SetSize="128 128"></TextureRect>
+                <TextureRect Name="BodyPartIconRightLeg" VerticalAlignment="Center" Margin="48 0 48 24" HorizontalAlignment="Center" Stretch="Scale" SetSize="128 128"></TextureRect>
+            </TextureRect>
         </TextureRect>
     </ScrollContainer>
 </controls:FancyWindow>

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -17,6 +17,10 @@ using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Radium.Medical.Surgery.Events;
+using Content.Shared.Radium.Medical.Surgery.Systems;
+using Content.Client.Radium.Medical.Surgery.UI.Widgets.Systems;
+using Content.Shared.Body.Part;
 
 namespace Content.Client.HealthAnalyzer.UI
 {
@@ -124,6 +128,154 @@ namespace Content.Client.HealthAnalyzer.UI
                 GroupsContainer.AddChild(box);
             }
 
+            if (msg.DamagedBodyParts == null)
+                return;
+            BaseDollTransparent.Texture = Texture.Transparent;
+            foreach (var pair in msg.DamagedBodyParts)
+            {
+                switch (pair.Key.Item1)
+                {
+                    case BodyPartType.Head:
+                        if (pair.Value.Item2)
+                        {
+                            BodyPartIconHead.TexturePath = "/Textures/Radium/Interface/Surgery/test_doll/head7.png";
+                            break;
+                        }
+
+                        BodyPartIconHead.TexturePath = pair.Value.Item1 switch
+                        {
+                            0 => "/Textures/Radium/Interface/Surgery/test_doll/head0.png",
+                            1 => "/Textures/Radium/Interface/Surgery/test_doll/head1.png",
+                            2 => "/Textures/Radium/Interface/Surgery/test_doll/head2.png",
+                            3 => "/Textures/Radium/Interface/Surgery/test_doll/head3.png",
+                            4 => "/Textures/Radium/Interface/Surgery/test_doll/head4.png",
+                            5 => "/Textures/Radium/Interface/Surgery/test_doll/head5.png",
+                            6 => "/Textures/Radium/Interface/Surgery/test_doll/head6.png",
+                            _ => "/Textures/Radium/Interface/Surgery/test_doll/head6.png"
+                        };
+                        break;
+                    case BodyPartType.Other:
+                        break;
+                    case BodyPartType.Torso:
+                        if (pair.Value.Item2)
+                        {
+                            BodyPartIconTorso.TexturePath = "/Textures/Radium/Interface/Surgery/test_doll/chest7.png";
+                            break;
+                        }
+
+                        BodyPartIconTorso.TexturePath = pair.Value.Item1 switch
+                        {
+                            0 => "/Textures/Radium/Interface/Surgery/test_doll/chest0.png",
+                            1 => "/Textures/Radium/Interface/Surgery/test_doll/chest1.png",
+                            2 => "/Textures/Radium/Interface/Surgery/test_doll/chest2.png",
+                            3 => "/Textures/Radium/Interface/Surgery/test_doll/chest3.png",
+                            4 => "/Textures/Radium/Interface/Surgery/test_doll/chest4.png",
+                            5 => "/Textures/Radium/Interface/Surgery/test_doll/chest5.png",
+                            6 => "/Textures/Radium/Interface/Surgery/test_doll/chest6.png",
+                            _ => "/Textures/Radium/Interface/Surgery/test_doll/chest6.png"
+                        };
+                        break;
+                    case BodyPartType.Arm:
+                        if (pair.Key.Item2 == BodyPartSymmetry.Left)
+                        {
+                            if (pair.Value.Item2)
+                            {
+                                BodyPartIconLeftHand.TexturePath =
+                                    "/Textures/Radium/Interface/Surgery/test_doll/l_arm7.png";
+                                break;
+                            }
+
+                            BodyPartIconLeftHand.TexturePath = pair.Value.Item1 switch
+                            {
+                                0 => "/Textures/Radium/Interface/Surgery/test_doll/l_arm0.png",
+                                1 => "/Textures/Radium/Interface/Surgery/test_doll/l_arm1.png",
+                                2 => "/Textures/Radium/Interface/Surgery/test_doll/l_arm2.png",
+                                3 => "/Textures/Radium/Interface/Surgery/test_doll/l_arm3.png",
+                                4 => "/Textures/Radium/Interface/Surgery/test_doll/l_arm4.png",
+                                5 => "/Textures/Radium/Interface/Surgery/test_doll/l_arm5.png",
+                                6 => "/Textures/Radium/Interface/Surgery/test_doll/l_arm6.png",
+                                _ => "/Textures/Radium/Interface/Surgery/test_doll/l_arm6.png"
+                            };
+                        }
+                        else
+                        {
+                            if (pair.Value.Item2)
+                            {
+                                BodyPartIconRightHand.TexturePath =
+                                    "/Textures/Radium/Interface/Surgery/test_doll/r_arm7.png";
+                                break;
+                            }
+
+                            BodyPartIconRightHand.TexturePath = pair.Value.Item1 switch
+                            {
+                                0 => "/Textures/Radium/Interface/Surgery/test_doll/r_arm0.png",
+                                1 => "/Textures/Radium/Interface/Surgery/test_doll/r_arm1.png",
+                                2 => "/Textures/Radium/Interface/Surgery/test_doll/r_arm2.png",
+                                3 => "/Textures/Radium/Interface/Surgery/test_doll/r_arm3.png",
+                                4 => "/Textures/Radium/Interface/Surgery/test_doll/r_arm4.png",
+                                5 => "/Textures/Radium/Interface/Surgery/test_doll/r_arm5.png",
+                                6 => "/Textures/Radium/Interface/Surgery/test_doll/r_arm6.png",
+                                _ => "/Textures/Radium/Interface/Surgery/test_doll/r_arm6.png"
+                            };
+                        }
+
+                        break;
+                    case BodyPartType.Hand:
+                        break;
+                    case BodyPartType.Leg:
+                        if (pair.Key.Item2 == BodyPartSymmetry.Left)
+                        {
+                            if (pair.Value.Item2)
+                            {
+                                BodyPartIconLeftLeg.TexturePath =
+                                    "/Textures/Radium/Interface/Surgery/test_doll/l_leg7.png";
+                                break;
+                            }
+
+                            BodyPartIconLeftLeg.TexturePath = pair.Value.Item1 switch
+                            {
+                                0 => "/Textures/Radium/Interface/Surgery/test_doll/l_leg0.png",
+                                1 => "/Textures/Radium/Interface/Surgery/test_doll/l_leg1.png",
+                                2 => "/Textures/Radium/Interface/Surgery/test_doll/l_leg2.png",
+                                3 => "/Textures/Radium/Interface/Surgery/test_doll/l_leg3.png",
+                                4 => "/Textures/Radium/Interface/Surgery/test_doll/l_leg4.png",
+                                5 => "/Textures/Radium/Interface/Surgery/test_doll/l_leg5.png",
+                                6 => "/Textures/Radium/Interface/Surgery/test_doll/l_leg6.png",
+                                _ => "/Textures/Radium/Interface/Surgery/test_doll/l_leg6.png"
+                            };
+                        }
+                        else
+                        {
+                            if (pair.Value.Item2)
+                            {
+                                BodyPartIconRightLeg.TexturePath =
+                                    "/Textures/Radium/Interface/Surgery/test_doll/r_leg7.png";
+                                break;
+                            }
+
+                            BodyPartIconRightLeg.TexturePath = pair.Value.Item1 switch
+                            {
+                                0 => "/Textures/Radium/Interface/Surgery/test_doll/r_leg0.png",
+                                1 => "/Textures/Radium/Interface/Surgery/test_doll/r_leg1.png",
+                                2 => "/Textures/Radium/Interface/Surgery/test_doll/r_leg2.png",
+                                3 => "/Textures/Radium/Interface/Surgery/test_doll/r_leg3.png",
+                                4 => "/Textures/Radium/Interface/Surgery/test_doll/r_leg4.png",
+                                5 => "/Textures/Radium/Interface/Surgery/test_doll/r_leg5.png",
+                                6 => "/Textures/Radium/Interface/Surgery/test_doll/r_leg6.png",
+                                _ => "/Textures/Radium/Interface/Surgery/test_doll/r_leg6.png"
+                            };
+                        }
+
+                        break;
+                    case BodyPartType.Foot:
+                        break;
+                    case BodyPartType.Tail:
+                        break;
+                    default:
+                        throw new Exception($"No body part with value: {pair.Key.Item1}");
+                }
+            }
+
             if (msg.SurgeryData!.Value.LocalizedName != "")
             {
                 var step = msg.SurgeryData.Value;
@@ -135,7 +287,10 @@ namespace Content.Client.HealthAnalyzer.UI
                 SurgeryStepDesc.Text = step.LocalizedDescription;
                 if (step.Icon == null)
                     return;
-                SurgeryIcon.Texture = _spriteSystem.Frame0(new SpriteSpecifier.Rsi(new ResPath("/Textures/Radium/Interface/instructions.rsi"), step.Icon));
+                SurgeryIcon.Texture =
+                    _spriteSystem.Frame0(
+                        new SpriteSpecifier.Rsi(new ResPath("/Textures/Radium/Interface/instructions.rsi"), step.Icon));
+                // BodyPartsDescription.Text = "";
             }
             else
             {
@@ -144,10 +299,12 @@ namespace Content.Client.HealthAnalyzer.UI
                 SurgeryStep.Text = "";
                 SurgeryStepDesc.Text = "";
                 SurgeryIcon.Texture = Texture.Transparent;
-            }
+                // BodyPartsDescription.Text = Loc.GetString("health-analyzer-window-doll-description");
 
-            //SetHeight = AnalyzerHeight;
-            //SetWidth = AnalyzerWidth;
+
+                //SetHeight = AnalyzerHeight;
+                //SetWidth = AnalyzerWidth;
+            }
         }
 
         private void DrawDiagnosticGroups(

--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -21,6 +21,8 @@ using Content.Client.Lobby;
 using Content.Client.Replay;
 using Content.Shared.Administration.Managers;
 using Content.Shared.Players.PlayTimeTracking;
+using Content.Client.Radium.Medical.Surgery.UI.Widgets.Systems;
+using Content.Shared.Radium.Medical.Surgery.Systems;
 
 
 namespace Content.Client.IoC
@@ -57,6 +59,7 @@ namespace Content.Client.IoC
             collection.Register<ContentReplayPlaybackManager, ContentReplayPlaybackManager>();
             collection.Register<ISharedPlaytimeManager, JobRequirementsManager>();
             collection.Register<DebugMonitorManager>();
+            collection.Register<ClientDamagePartsSystem, ClientDamagePartsSystem>();
         }
     }
 }

--- a/Content.Client/Radium/Medical/Surgery/UI/Widgets/DamagePartsUi.xaml.cs
+++ b/Content.Client/Radium/Medical/Surgery/UI/Widgets/DamagePartsUi.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Content.Client.Guidebook.Richtext;
+using Content.Client.Radium.Medical.Surgery.UI.Widgets.Systems;
 using Content.Shared.Body.Part;
 using Content.Shared.Radium.Medical.Surgery.Systems;
 using Robust.Client.UserInterface.Controls;
@@ -71,7 +72,7 @@ public sealed partial class DamagePartsUi : UIWidget
         LLeg.Texture = Texture.Transparent;
         RLeg.Texture = Texture.Transparent;
     }
-    public void SyncControls(DamagePartsSystem partsSystem,
+    public void SyncControls(ClientDamagePartsSystem partsSystem,
         IReadOnlyDictionary<(BodyPartType, BodyPartSymmetry), (int, bool)> partsStates)
     {
         Clear();

--- a/Content.Client/Radium/Medical/Surgery/UI/Widgets/Systems/ClientDamagePartsSystem.cs
+++ b/Content.Client/Radium/Medical/Surgery/UI/Widgets/Systems/ClientDamagePartsSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Body.Components;
+﻿using Content.Client.Body.Systems;
+using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
@@ -12,9 +13,15 @@ namespace Content.Client.Radium.Medical.Surgery.UI.Widgets.Systems;
 public sealed class ClientDamagePartsSystem : DamagePartsSystem
 {
     [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
 
     public event EventHandler<IReadOnlyDictionary<(BodyPartType, BodyPartSymmetry), (int, bool)>>?
         SyncParts;
+
+    public override IEnumerable<(EntityUid Id, BodyPartComponent Component)> GetBodyChildren(EntityUid euid, BodyComponent bodyComponent)
+    {
+        return _entManager.System<BodySystem>().GetBodyChildren(euid, bodyComponent);
+    }
 
     public event EventHandler? Dispose;
 
@@ -48,4 +55,5 @@ public sealed class ClientDamagePartsSystem : DamagePartsSystem
     {
         Dispose?.Invoke(this, EventArgs.Empty);
     }
+
 }

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.PowerCell;
 using Content.Shared.Radium.Medical.Surgery.Components;
 using Content.Shared.Radium.Medical.Surgery.Prototypes;
+using Content.Shared.Radium.Medical.Surgery.Systems;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
@@ -217,7 +218,6 @@ public sealed class HealthAnalyzerSystem : EntitySystem
                 }
             }
         }
-
         _uiSystem.ServerSendUiMessage(healthAnalyzer,
             HealthAnalyzerUiKey.Key,
             new HealthAnalyzerScannedUserMessage(

--- a/Content.Server/Radium/Medical/Surgery/Systems/ServerDamagePartsSystem.cs
+++ b/Content.Server/Radium/Medical/Surgery/Systems/ServerDamagePartsSystem.cs
@@ -1,0 +1,15 @@
+using Content.Server.Body.Systems;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Part;
+using Content.Shared.Radium.Medical.Surgery.Systems;
+
+namespace Content.Server.Radium.Medical.Surgery.Systems;
+
+public sealed class ServerDamagePartsSystem : DamagePartsSystem
+{
+    [Dependency] private readonly BodySystem _bodySystem = default!;
+    public override IEnumerable<(EntityUid Id, BodyPartComponent Component)> GetBodyChildren(EntityUid euid, BodyComponent bodyComponent)
+    {
+        return _bodySystem.GetBodyChildren(euid, bodyComponent);
+    }
+}

--- a/Content.Server/Radium/Medical/Surgery/Systems/SurgerySystem.cs
+++ b/Content.Server/Radium/Medical/Surgery/Systems/SurgerySystem.cs
@@ -47,7 +47,7 @@ public sealed partial class SurgerySystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
-    [Dependency] private readonly DamagePartsSystem _damageParts = default!;
+    [Dependency] private readonly ServerDamagePartsSystem _damageParts = default!;
     [Dependency] private readonly DrunkSystem _drunkSystem = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly StutteringSystem _stutteringSystem = default!;

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Body.Part;
 using Content.Shared.Radium.Medical.Surgery.Components;
 using Robust.Shared.Serialization;
 
@@ -15,8 +16,9 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
     public bool? ScanMode;
     public bool? Bleeding;
     public SurgeryStepData? SurgeryData;
+    public IReadOnlyDictionary<(BodyPartType, BodyPartSymmetry), (int, bool)>? DamagedBodyParts;
 
-    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, SurgeryStepData? surgeryStep)
+    public HealthAnalyzerScannedUserMessage(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, SurgeryStepData? surgeryStep, IReadOnlyDictionary<(BodyPartType, BodyPartSymmetry), (int, bool)>? damagedBodyParts = null)
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
@@ -24,6 +26,7 @@ public sealed class HealthAnalyzerScannedUserMessage : BoundUserInterfaceMessage
         ScanMode = scanMode;
         Bleeding = bleeding;
         SurgeryData = surgeryStep;
+        DamagedBodyParts = damagedBodyParts;
     }
 }
 

--- a/Content.Shared/Radium/Medical/Surgery/Systems/DamagePartsSystem.cs
+++ b/Content.Shared/Radium/Medical/Surgery/Systems/DamagePartsSystem.cs
@@ -1,19 +1,13 @@
-﻿using System.Linq;
-using Content.Shared.Body.Components;
+﻿using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Systems;
-using Content.Shared.Humanoid;
-using Content.Shared.Radium.Medical.Surgery.Components;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
 
 namespace Content.Shared.Radium.Medical.Surgery.Systems;
 
-public class DamagePartsSystem : EntitySystem
+public abstract class DamagePartsSystem : EntitySystem
 {
     //[Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     //[Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly SharedBodySystem _bodySystem = default!;
 
     public IReadOnlyDictionary<(BodyPartType, BodyPartSymmetry), (int, bool)> GetDamagedParts(EntityUid euid)
     {
@@ -24,7 +18,7 @@ public class DamagePartsSystem : EntitySystem
         //}
         if (!TryComp<BodyComponent>(euid, out var bodyComponent))
             return partsWounds;
-        foreach (var (_, component) in _bodySystem.GetBodyChildren(euid, bodyComponent))
+        foreach (var (_, component) in GetBodyChildren(euid, bodyComponent))
         {
             //var organs = _bodySystem.GetPartOrgans(adjacentId).ToList();
             //var isDamaged = organs.Select(g => g.Component.Condition != OrganCondition.Healthy).ToList().Contains(true);
@@ -42,4 +36,8 @@ public class DamagePartsSystem : EntitySystem
 
         return partsWounds;
     }
+
+
+    public abstract IEnumerable<(EntityUid Id, BodyPartComponent Component)> GetBodyChildren(EntityUid euid,
+        BodyComponent bodyComponent);
 }


### PR DESCRIPTION
## Описание PR
Теперь медицинский сканер будет показывать, какие именно у сканируемого игрока повреждения, чтобы не пришлось по несколько раз спрашивать где-что-как болит.

**Медиа**

![Content Client_QrJ13H4FW5](https://github.com/Cybersun-Industries/Radium-Build/assets/49454110/7b8714eb-a53c-4930-bf44-5a7ea873c33c)


**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [ ] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [ ] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Изменения**

:cl: Xo6a
- add: -
- remove: -
- tweak: теперь сканер здоровья будет показывать повреждения конечностей у сканируемого существа
- fix: -
